### PR TITLE
Specify stringAsFactors = TRUE to read.csv()

### DIFF
--- a/3-play-golf/app.R
+++ b/3-play-golf/app.R
@@ -13,8 +13,10 @@ library(RCurl)
 library(randomForest)
 
 # Read data
-weather <- read.csv(text = getURL("https://raw.githubusercontent.com/dataprofessor/data/master/weather-weka.csv") )
-
+weather <- read.csv(text = getURL("https://raw.githubusercontent.com/dataprofessor/data/master/weather-weka.csv"), 
+                    stringsAsFactors=TRUE) ### automatic conversion of characters to factors have been deprecated 
+                                           ### use stringAsFactors = TRUE to simulate the autoconversion of character to factors
+                                           ### check out this (https://blog.r-project.org/2020/02/16/stringsasfactors/) documentation by Kurt Hornik about the reasoning behind R's decision of altering this default behaviour
 # Build model
 model <- randomForest(play ~ ., data = weather, ntree = 500, mtry = 4, importance = TRUE)
 


### PR DESCRIPTION
read.csv no longer automatically converts characters to factors, and this produces a warning message: 

"Warning in randomForest.default(m, y, ...) :
  The response has five or fewer unique values.  Are you sure you want to do regression?
Warning in mean.default(y) :
  argument is not numeric or logical: returning NA
Error in y - ymean : non-numeric argument to binary operator"

By adding in stringAsFactors = TRUE to the read.csv function, the code will simulate the legacy behaviour of auto-converting characters to factors and the app will be loaded properly

here is an article (https://blog.r-project.org/2020/02/16/stringsasfactors/) by Kurt Hornik talking about the reasoning behind R's decision of altering this default behaviour